### PR TITLE
Add minimal Foundry VTT system skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# ModuleFoundry Repository
+
+This repository contains a Visual Studio project and a minimal Foundry VTT system skeleton located in `simple-system/`.
+
+The system folder is intended as a clean starting point for building your own game system.

--- a/simple-system/README.md
+++ b/simple-system/README.md
@@ -1,0 +1,13 @@
+# Simple System
+
+This is a minimal skeleton for a Foundry VTT game system.
+
+## Structure
+
+- `system.json` - System manifest.
+- `lang/` - Localization files.
+- `templates/` - Handlebar templates.
+- `scripts/` - System JavaScript.
+- `styles/` - System CSS.
+
+Modify these files to begin developing your own system.

--- a/simple-system/lang/en.json
+++ b/simple-system/lang/en.json
@@ -1,0 +1,5 @@
+{
+  "SIMPLE": {
+    "GREETING": "Hello from Simple System"
+  }
+}

--- a/simple-system/scripts/main.js
+++ b/simple-system/scripts/main.js
@@ -1,0 +1,1 @@
+console.log("Simple System loaded");

--- a/simple-system/styles/main.css
+++ b/simple-system/styles/main.css
@@ -1,0 +1,1 @@
+body { font-family: sans-serif; }

--- a/simple-system/system.json
+++ b/simple-system/system.json
@@ -1,0 +1,15 @@
+{
+  "name": "simple-system",
+  "title": "Simple System",
+  "description": "A minimal Foundry VTT system template",
+  "version": "0.0.1",
+  "authors": [{ "name": "Your Name" }],
+  "minimumCoreVersion": "11",
+  "compatibleCoreVersion": "11",
+  "scripts": ["scripts/main.js"],
+  "styles": ["styles/main.css"],
+  "languages": [
+    {"lang": "en", "name": "English", "path": "lang/en.json"}
+  ],
+  "packs": []
+}

--- a/simple-system/templates/template.html
+++ b/simple-system/templates/template.html
@@ -1,0 +1,1 @@
+<h1>{{localize "SIMPLE.GREETING"}}</h1>


### PR DESCRIPTION
## Summary
- add README describing the repo contents
- add minimal Foundry VTT system template under `simple-system/`

## Testing
- `npm test --silent`
- `dotnet build ModuleFoundry.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686642fdbf4c83338ecf61b495ae7f10