### PR TITLE
Implement basic wargame actor types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 This repository contains a Visual Studio project and a minimal Foundry VTT system skeleton located in `simple-system/`.
 
-The system folder is intended as a clean starting point for building your own game system.
+The `simple-system` folder now demonstrates a basic wargame implementation with
+three actor types that have movement, attack and defense statistics.

--- a/simple-system/README.md
+++ b/simple-system/README.md
@@ -2,11 +2,16 @@
 
 This is a minimal skeleton for a Foundry VTT game system.
 
+It now includes basic components for a simple wargame. The system defines three
+actor types (`infantry`, `cavalry`, and `artillery`) which each track movement,
+attack and defense values.
+
 ## Structure
 
 - `system.json` - System manifest.
 - `lang/` - Localization files.
 - `templates/` - Handlebar templates.
+- `template.json` - Default statistics for actor types.
 - `scripts/` - System JavaScript.
 - `styles/` - System CSS.
 

--- a/simple-system/lang/en.json
+++ b/simple-system/lang/en.json
@@ -1,5 +1,13 @@
 {
   "SIMPLE": {
     "GREETING": "Hello from Simple System"
+  },
+  "WARGAME": {
+    "MOVE": "Movement",
+    "ATTACK": "Attack",
+    "DEFENSE": "Defense",
+    "INFANTRY": "Infantry",
+    "CAVALRY": "Cavalry",
+    "ARTILLERY": "Artillery"
   }
 }

--- a/simple-system/scripts/wargame.js
+++ b/simple-system/scripts/wargame.js
@@ -1,0 +1,25 @@
+Hooks.once('init', () => {
+  console.log('Wargame system initializing');
+
+  class WargameActor extends Actor {
+    prepareData() {
+      super.prepareData();
+      const system = this.system;
+      system.move ??= 0;
+      system.attack ??= 0;
+      system.defense ??= 0;
+    }
+  }
+
+  CONFIG.Actor.documentClass = WargameActor;
+
+  class WargameActorSheet extends ActorSheet {
+    /** @override */
+    get template() {
+      return `systems/${game.system.id}/templates/actor-sheet.html`;
+    }
+  }
+
+  Actors.registerSheet('wargame', WargameActorSheet, { makeDefault: true });
+});
+

--- a/simple-system/styles/main.css
+++ b/simple-system/styles/main.css
@@ -1,1 +1,5 @@
 body { font-family: sans-serif; }
+
+.wargame-sheet div {
+  margin-bottom: 0.5em;
+}

--- a/simple-system/system.json
+++ b/simple-system/system.json
@@ -2,14 +2,15 @@
   "name": "simple-system",
   "title": "Simple System",
   "description": "A minimal Foundry VTT system template",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "authors": [{ "name": "Your Name" }],
   "minimumCoreVersion": "11",
   "compatibleCoreVersion": "11",
-  "scripts": ["scripts/main.js"],
+  "scripts": ["scripts/main.js", "scripts/wargame.js"],
   "styles": ["styles/main.css"],
   "languages": [
     {"lang": "en", "name": "English", "path": "lang/en.json"}
   ],
+  "actorTypes": ["infantry", "cavalry", "artillery"],
   "packs": []
 }

--- a/simple-system/template.json
+++ b/simple-system/template.json
@@ -1,0 +1,19 @@
+{
+  "actor": {
+    "infantry": {
+      "move": 6,
+      "attack": 2,
+      "defense": 1
+    },
+    "cavalry": {
+      "move": 8,
+      "attack": 3,
+      "defense": 2
+    },
+    "artillery": {
+      "move": 4,
+      "attack": 4,
+      "defense": 1
+    }
+  }
+}

--- a/simple-system/templates/actor-sheet.html
+++ b/simple-system/templates/actor-sheet.html
@@ -1,0 +1,15 @@
+<form class="wargame-sheet">
+  <h1>{{actor.name}}</h1>
+  <div>
+    <label>{{localize "WARGAME.MOVE"}}</label>
+    <input type="number" name="system.move" value="{{system.move}}" />
+  </div>
+  <div>
+    <label>{{localize "WARGAME.ATTACK"}}</label>
+    <input type="number" name="system.attack" value="{{system.attack}}" />
+  </div>
+  <div>
+    <label>{{localize "WARGAME.DEFENSE"}}</label>
+    <input type="number" name="system.defense" value="{{system.defense}}" />
+  </div>
+</form>


### PR DESCRIPTION
## Summary
- describe simple wargame support in README docs
- define actor types and stats in localization
- create actor sheet and styling
- register new actor and sheet via wargame.js
- bump system version and load new script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866448c217083338e33872ab5d44734