### PR TITLE
Fix missing actor type during creation

### DIFF
--- a/simple-system/scripts/wargame.js
+++ b/simple-system/scripts/wargame.js
@@ -21,5 +21,11 @@ Hooks.once('init', () => {
   }
 
   Actors.registerSheet('wargame', WargameActorSheet, { makeDefault: true });
+
+  Hooks.on('preCreateActor', (actor, data, options, userId) => {
+    if (!data.type) {
+      data.type = 'infantry';
+    }
+  });
 });
 


### PR DESCRIPTION
## Summary
- add a `preCreateActor` hook to enforce a default actor type

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_686647384a948333a22393eade2f2c89