### PR TITLE
Update actor template format

### DIFF
--- a/simple-system/template.json
+++ b/simple-system/template.json
@@ -1,19 +1,25 @@
 {
-  "actor": {
+  "Actor": {
     "infantry": {
-      "move": 6,
-      "attack": 2,
-      "defense": 1
+      "system": {
+        "move": 6,
+        "attack": 2,
+        "defense": 1
+      }
     },
     "cavalry": {
-      "move": 8,
-      "attack": 3,
-      "defense": 2
+      "system": {
+        "move": 8,
+        "attack": 3,
+        "defense": 2
+      }
     },
     "artillery": {
-      "move": 4,
-      "attack": 4,
-      "defense": 1
+      "system": {
+        "move": 4,
+        "attack": 4,
+        "defense": 1
+      }
     }
   }
 }

--- a/test/verify-actor-defaults.js
+++ b/test/verify-actor-defaults.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const assert = require('assert');
+
+const template = JSON.parse(fs.readFileSync('simple-system/template.json', 'utf8'));
+
+function createActor(type) {
+  const data = JSON.parse(JSON.stringify(template.Actor[type] || {}));
+  return { type, ...data };
+}
+
+function runTests() {
+  const infantry = createActor('infantry');
+  assert.deepStrictEqual(infantry.system, { move: 6, attack: 2, defense: 1 });
+
+  const cavalry = createActor('cavalry');
+  assert.deepStrictEqual(cavalry.system, { move: 8, attack: 3, defense: 2 });
+
+  const artillery = createActor('artillery');
+  assert.deepStrictEqual(artillery.system, { move: 4, attack: 4, defense: 1 });
+
+  console.log('All actor defaults verified.');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- reformat simple-system's template.json to use `Actor` as the root key
- nest move, attack, and defense values under `system`
- add a small verification script demonstrating actor defaults

## Testing
- `node test/verify-actor-defaults.js`

------
https://chatgpt.com/codex/tasks/task_e_6866473dc7988333b1d480f471434404