### PR TITLE
Allow actor type selection on creation

### DIFF
--- a/simple-system/scripts/wargame.js
+++ b/simple-system/scripts/wargame.js
@@ -11,6 +11,12 @@ Hooks.once('init', () => {
     }
   }
 
+  CONFIG.Actor.typeLabels = {
+    infantry: game.i18n.localize('WARGAME.INFANTRY'),
+    cavalry: game.i18n.localize('WARGAME.CAVALRY'),
+    artillery: game.i18n.localize('WARGAME.ARTILLERY')
+  };
+
   CONFIG.Actor.documentClass = WargameActor;
 
   class WargameActorSheet extends ActorSheet {


### PR DESCRIPTION
## Summary
- expose labels for each actor type so Foundry's actor creation dialog shows a type dropdown

## Testing
- `node test/verify-actor-defaults.js`


------
https://chatgpt.com/codex/tasks/task_e_68664ac091288333a75b59335ffb75ee